### PR TITLE
Set C# language version to 7.3

### DIFF
--- a/packages/c#/csharp-cgdk.csproj
+++ b/packages/c#/csharp-cgdk.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By default, the latest major C# version is used, 7.0 at the moment.
It'd be nice to have C# 7.3 features like `stackalloc` arrays.