### PR TITLE
fix custom rendering in ruby package

### DIFF
--- a/packages/ruby/remote_process_client.rb
+++ b/packages/ruby/remote_process_client.rb
@@ -30,6 +30,6 @@ class RemoteProcessClient
     return Rules.new(json)
   end
   def write(actions, custom_rendering)
-    write_line(actions.to_json + '|' + custom_rendering + '\n<end>')
+    write_line(actions.to_json + '|' + custom_rendering + "\n<end>")
   end
 end


### PR DESCRIPTION
Одинарные кавычки заменены на двойные, чтобы не было экранирования \n